### PR TITLE
spawn_point_guid -> spawn_point_id

### DIFF
--- a/src/Item.js
+++ b/src/Item.js
@@ -51,7 +51,7 @@ class Item {
       message: {
         item_id: this.item_id,
         encounter_id: pokemon.encounter_id,
-        spawn_point_guid: pokemon.spawn_point_id,
+        spawn_point_id: pokemon.spawn_point_id,
       }
     }])
 


### PR DESCRIPTION
Fixes Error: .POGOProtos.Networking.Requests.Messages.UseItemCaptureMessage#spawn_point_guid is not a field: undefined