### PR TITLE
Fix TypeError: Cannot set property 'lastCheckpointSearch' of undefined

### DIFF
--- a/src/Fort.js
+++ b/src/Fort.js
@@ -209,7 +209,7 @@ class Checkpoint extends Fort {
         fort_longitude: this.longitude
       }
     }])
-    this.player.lastCheckpointSearch = search
+    this.parent.player.lastCheckpointSearch = search
     this.parent.log.info('[+] Search complete')
     return search
   }


### PR DESCRIPTION
´´´
TypeError: Cannot set property 'lastCheckpointSearch' of undefined
    at Checkpoint._callee$ (.../node_modules/pokemongo-api/dist/Fort.js:293:50)
    at tryCatch (/usr/lib/node_modules/babel-cli/node_modules/regenerator-runtime/runtime.js:62:40)
    at GeneratorFunctionPrototype.invoke [as _invoke] (/usr/lib/node_modules/babel-cli/node_modules/regenerator-runtime/runtime.js:336:22)
    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/usr/lib/node_modules/babel-cli/node_modules/regenerator-runtime/runtime.js:95:21)
    at step (.../node_modules/pokemongo-api/dist/Fort.js:15:191)
    at .../node_modules/pokemongo-api/dist/Fort.js:15:368
    at run (/usr/lib/node_modules/babel-cli/node_modules/core-js/modules/es6.promise.js:87:22)
    at /usr/lib/node_modules/babel-cli/node_modules/core-js/modules/es6.promise.js:100:28
    at flush (/usr/lib/node_modules/babel-cli/node_modules/core-js/modules/_microtask.js:18:9)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickDomainCallback (internal/process/next_tick.js:122:9)
´´´