### PR TITLE
add transform-runtime & remove babel-polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,12 @@
-{ 
+{
   "presets": [
     "es2015",
     "stage-0"
-  ], 
+  ],
   "plugins": [
     ["babel-project-relative-import", {
       "sourceDir": "src/"
-    }]
+    }],
+    "transform-runtime"
   ],
-} 
-
+}

--- a/example/index.js
+++ b/example/index.js
@@ -1,3 +1,1 @@
-import 'babel-polyfill'
-import 'babel-register'
 import './example.js'

--- a/example/test.js
+++ b/example/test.js
@@ -1,0 +1,13 @@
+// use script: npm run compile
+// you can use compiled dist in your own project
+
+// es6 use
+// import PokeAPI from 'pokemongo-api'
+//
+// es5 use
+// var PokeAPI = require('pokemongo-api')
+
+// test dist
+import PokeAPI from '../dist'
+const Poke = new PokeAPI()
+console.log(Poke)

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "version": "0.0.0-semantically-released",
   "scripts": {
     "commit": "git-cz",
-    "compile": "babel --presets es2015,stage-0 -d dist/ src/",
-    "compile-example": "babel --presets es2015,stage-0 -d example-es5/ example/",
+    "compile": "babel -r babel-register -d dist/ src/",
+    "compile-example": "babel -r babel-register -d example-es5/ example/",
     "prepublish": "npm run compile",
     "example": "babel-node example/example.js",
+    "test-es5": "node example-es5/test.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -24,6 +25,7 @@
   "devDependencies": {
     "babel-cli": "^6.11.4",
     "babel-core": "^6.11.4",
+    "babel-plugin-transform-runtime": "^6.12.0",
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",


### PR DESCRIPTION
As https://github.com/stoffern/pokemongo-api/issues/150 mentioned,
When someone wants to dist "pokemongo-api" under their own project's node_modules
It has to use require-hook (means require('babel-polyfill')) 
and it will pollute global variable on top of the code.

So I change using babel-polyfill to transform-runtime to do polyfill and regenerator 
after npm run compile, you can use require(es5) or import(es6) without any possible
"Unexpected token import" or "regeneratorRuntime is not defined" 😄 